### PR TITLE
Fix an issue with a non standard encoding name (explicitly: utf8).

### DIFF
--- a/lib/faraday/encoding.rb
+++ b/lib/faraday/encoding.rb
@@ -2,17 +2,47 @@ require "faraday"
 
 module Faraday
   class Faraday::Encoding < Faraday::Middleware
+    def self.mappings
+      {
+        'utf8' => 'utf-8'
+      }
+    end
+
     def call(environment)
       @app.call(environment).on_complete do |env|
-        if /charset=([^;|$]+)/.match(env[:response_headers][:content_type])
-          begin
-            content_charset = ::Encoding.find Regexp.last_match(1)
-          rescue
-            nil
-          end
-        end
-        env[:body].force_encoding content_charset if content_charset
+        @env = env
+        env[:body].force_encoding(content_charset) if content_charset
       end
+    end
+
+    private
+
+    # @return [Encoding|NilClass] returns Encoding or nil
+    def content_charset
+      @content_charset ||= ::Encoding.find encoding_name rescue nil
+    end
+
+    # @return [String] returns a string representing encoding name if it is find in the CONTENT TYPE header
+    def encoding_name
+      @encoding_name ||= begin
+        if /charset=([^;|$]+)/.match(content_type)
+          mapped_encoding(Regexp.last_match(1))
+        end
+      end
+    end
+
+    # @param [String] encoding_name
+    # @return [String] tries to find a mapping for the encoding name
+    # ex: returns 'utf-8' for encoding_name 'utf8'
+    # if mapping is not found - return the same input parameter `encoding_name`
+    # Look at `self.mappings` to see which mappings are available
+    def mapped_encoding(encoding_name)
+      self.class.mappings.fetch(encoding_name, default = encoding_name)
+    end
+
+    # @return [String]
+    def content_type
+      @env[:response_headers][:content_type]
     end
   end
 end

--- a/spec/faraday/encoding_spec.rb
+++ b/spec/faraday/encoding_spec.rb
@@ -18,17 +18,50 @@ describe Faraday::Encoding do
 
   let(:response_status) { 200 }
   let(:response_headers) do
-    { 'content-type' => 'text/plain; charset=utf-8' }
-  end
-  let(:response_body) do
-    'ねこ'.force_encoding(Encoding::ASCII_8BIT)
+    { 'content-type' => "text/plain; charset=#{response_encoding}" }
   end
 
   context 'http adapter return binary encoded body' do
+    let(:response_encoding) do
+      'utf-8'
+    end
+    let(:response_body) do
+      'ねこ'.force_encoding(Encoding::ASCII_8BIT)
+    end
+
     it 'set encoding specified by http header' do
       response = client.get('/')
       expect(response.body.encoding).to eq(Encoding::UTF_8)
     end
   end
 
+  context 'deal correctly with a non standard encoding names' do
+    context 'utf8' do
+      let(:response_encoding) do
+        'utf8'
+      end
+      let(:response_body) do
+        'abc'.force_encoding(Encoding::ASCII_8BIT)
+      end
+
+      it 'set encoding to utf-8' do
+        response = client.get('/')
+        expect(response.body.encoding).to eq(Encoding::UTF_8)
+      end
+    end
+
+    context 'for unknown encoding' do
+      let(:response_encoding) do
+        'unknown-encoding'
+      end
+      let(:response_body) do
+        'abc'.force_encoding(Encoding::ASCII_8BIT)
+      end
+
+      it 'does not enforce encoding' do
+        response = client.get('/')
+        expect(response.body.encoding).to eq(Encoding::ASCII_8BIT)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This makes it possible to add mappings for a non standard encoding names.
Ex: "utf8" should be converted to a proper name "utf-8".
Adds spec to check that mapping is working and that we do not enforce encoding if we can't find one.
