### PR TITLE
Remove memoization

### DIFF
--- a/faraday-encoding.gemspec
+++ b/faraday-encoding.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency 'faraday_middleware', '~> 0.10'
 
   spec.add_runtime_dependency "faraday"
 end

--- a/lib/faraday/encoding.rb
+++ b/lib/faraday/encoding.rb
@@ -11,7 +11,9 @@ module Faraday
     def call(environment)
       @app.call(environment).on_complete do |env|
         @env = env
-        env[:body].force_encoding(content_charset) if content_charset
+        if encoding = content_charset
+          env[:body].force_encoding(encoding)
+        end
       end
     end
 
@@ -19,15 +21,13 @@ module Faraday
 
     # @return [Encoding|NilClass] returns Encoding or nil
     def content_charset
-      @content_charset ||= ::Encoding.find encoding_name rescue nil
+      ::Encoding.find encoding_name rescue nil
     end
 
     # @return [String] returns a string representing encoding name if it is find in the CONTENT TYPE header
     def encoding_name
-      @encoding_name ||= begin
-        if /charset=([^;|$]+)/.match(content_type)
-          mapped_encoding(Regexp.last_match(1))
-        end
+      if /charset=([^;|$]+)/.match(content_type)
+        mapped_encoding(Regexp.last_match(1))
       end
     end
 

--- a/spec/faraday/encoding_spec.rb
+++ b/spec/faraday/encoding_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Faraday::Encoding do
   let(:client) do
     Faraday.new do |connection|
+      connection.use FaradayMiddleware::FollowRedirects, limit: 10
       connection.response :encoding
       connection.adapter :test, stubs
     end
@@ -12,6 +13,9 @@ describe Faraday::Encoding do
     Faraday::Adapter::Test::Stubs.new do |stub|
       stub.get('/') do
         [response_status, response_headers, response_body]
+      end
+      stub.get('/redirected') do
+        [redirected_status, redirected_headers, redirected_body]
       end
     end
   end
@@ -62,6 +66,33 @@ describe Faraday::Encoding do
         response = client.get('/')
         expect(response.body.encoding).to eq(Encoding::ASCII_8BIT)
       end
+    end
+  end
+
+  context 'deal correctly with redirects that specify an encoding' do
+    # First request response with a redirect + a charset in the content-type header
+    let(:response_status) { 301 }
+    let(:response_headers) do
+      {
+        'content-type' => "text/plain; charset=utf-8",
+        'location' => '/redirected'
+      }
+    end
+    let(:response_body) { 'Redirected to /redirected' }
+
+    # The second request does not specify a charset in the content-type
+    let(:redirected_status) { 200 }
+    let(:redirected_headers) do
+      {
+        'content-type' => "text/html"
+      }
+    end
+    let(:redirected_body) do
+      'abc'.force_encoding(Encoding::ASCII_8BIT)
+    end
+    it 'does not memoize redirect encoding' do
+      response = client.get('/')
+      expect(response.body.encoding).to eq(Encoding::ASCII_8BIT)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "faraday-encoding"
+require "faraday_middleware"
 
 RSpec.configure do |config|
 end


### PR DESCRIPTION
Hi @ma2gedev!

I found that if a server responses with a redirect and at the same time with a content-type header that specifies a charset, that charset affects the next requests and it could force the encoding incorrectly, for example:

```
Request url_1 => status: 301, Location: url_2, Content-Type: text/plain; charset=iso-8859-1
Request url_2 => status: 200, Content-Type: text/html
```

and the body of url_2 is forced incorrectly to iso-8859-1

This PR remove the memoization so the encoding is evaluated in every request.

Juan.
