### PR TITLE
Remove unused variable

### DIFF
--- a/lib/faraday/encoding.rb
+++ b/lib/faraday/encoding.rb
@@ -37,7 +37,7 @@ module Faraday
     # if mapping is not found - return the same input parameter `encoding_name`
     # Look at `self.mappings` to see which mappings are available
     def mapped_encoding(encoding_name)
-      self.class.mappings.fetch(encoding_name, default = encoding_name)
+      self.class.mappings.fetch(encoding_name, encoding_name)
     end
 
     # @return [String]


### PR DESCRIPTION
There is a `default` variable being defined in the current 0.0.3 release which is unused within the scope of the defining method.
