### PR TITLE
Protect against mutating frozen strings

### DIFF
--- a/lib/faraday/encoding.rb
+++ b/lib/faraday/encoding.rb
@@ -12,6 +12,7 @@ module Faraday
       @app.call(environment).on_complete do |env|
         @env = env
         if encoding = content_charset
+          env[:body] = env[:body].dup if env[:body].frozen?
           env[:body].force_encoding(encoding)
         end
       end

--- a/spec/faraday/encoding_spec.rb
+++ b/spec/faraday/encoding_spec.rb
@@ -39,6 +39,20 @@ describe Faraday::Encoding do
     end
   end
 
+  context 'deal correctly with frozen strings' do
+    let(:response_encoding) do
+      'utf-8'
+    end
+    let(:response_body) do
+      'abc'.force_encoding(Encoding::ASCII_8BIT).freeze
+    end
+
+    it 'set encoding to utf-8' do
+      response = client.get('/')
+      expect(response.body.encoding).to eq(Encoding::UTF_8)
+    end
+  end
+
   context 'deal correctly with a non standard encoding names' do
     context 'utf8' do
       let(:response_encoding) do


### PR DESCRIPTION
When the response body is frozen, this library causes `RuntimeError: can't modify frozen String` exceptions to occur.

Frozen bodies can occur in various ways. A somewhat common case is when stubbing server responses in tests and directly (or more likely indirectly via a `# frozen_string_literal: true` magic comment) setting the stubbed body to a frozen string.