### PR TITLE
CI: Update patch versions in build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-  - 2.5.7
+  - 2.5.8
   - 2.6.5
-  - 2.7.0
-sudo: false
+  - 2.7.6
 cache: bundler


### PR DESCRIPTION
This PR updates the CI build matrix with the current patch versions.

This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).