### PR TITLE
CI: fix typo in Ruby 2.7 patch version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: ruby
 rvm:
   - 2.5.8
   - 2.6.5
-  - 2.7.6
+  - 2.7.2
 cache: bundler


### PR DESCRIPTION
Errr, apologies: 2.7.2 is the current latest: https://www.ruby-lang.org/en/news/2020/10/02/ruby-2-7-2-released/

Introduced by me, in #8 