### PR TITLE
Default encoding

### DIFF
--- a/lib/faraday/encoding.rb
+++ b/lib/faraday/encoding.rb
@@ -20,7 +20,7 @@ module Faraday
       end
 
       attr_accessor :default_encoding
-      end
+    end
 
     private
 
@@ -38,9 +38,8 @@ module Faraday
 
     # @return [TrueClass, FalseClass] checks if the charset derictive is present in the CONTENT TYPE header
     def charset_derective?
-      content_type.match?(/charset=/)
+      content_type&.match?(/charset=([^;|$]+)/)
     end
-
 
     # @param [String] encoding_name
     # @return [String] tries to find a mapping for the encoding name

--- a/lib/faraday/encoding.rb
+++ b/lib/faraday/encoding.rb
@@ -19,12 +19,8 @@ module Faraday
         }
       end
 
-      def default_encoding
-        @default_encoding ||= 'utf-8'
+      attr_accessor :default_encoding
       end
-
-      attr_writer :default_encoding
-    end
 
     private
 

--- a/lib/faraday/encoding.rb
+++ b/lib/faraday/encoding.rb
@@ -5,7 +5,7 @@ module Faraday
     def call(environment)
       @app.call(environment).on_complete do |env|
         @env = env
-        if encoding = charset_derective? ? content_charset : self.class.default_encoding
+        if encoding = charset_directive? ? content_charset : self.class.default_encoding
           env[:body] = env[:body].dup if env[:body].frozen?
           env[:body].force_encoding(encoding)
         end
@@ -36,8 +36,8 @@ module Faraday
       end
     end
 
-    # @return [TrueClass, FalseClass] checks if the charset derictive is present in the CONTENT TYPE header
-    def charset_derective?
+    # @return [TrueClass, FalseClass] checks if the charset directive is present in the CONTENT TYPE header
+    def charset_directive?
       content_type&.match?(/charset=([^;|$]+)/)
     end
 

--- a/spec/faraday/encoding_spec.rb
+++ b/spec/faraday/encoding_spec.rb
@@ -109,4 +109,33 @@ describe Faraday::Encoding do
       expect(response.body.encoding).to eq(Encoding::ASCII_8BIT)
     end
   end
+
+  context 'default encoding' do
+    around do |example|
+      encoding_was = Faraday::Encoding.default_encoding
+      Faraday::Encoding.default_encoding = Encoding::WINDOWS_1251
+      example.run
+      Faraday::Encoding.default_encoding = encoding_was
+    end
+
+    shared_examples 'uses default encoding' do
+      it do
+        response = client.get('/')
+        expect(response.body.encoding).to eq(Encoding::WINDOWS_1251)
+        expect(response.body.encode(Encoding::UTF_8)).to eq('привет')
+      end
+    end
+
+    context 'no content_type header' do
+      let(:response_headers) {}
+      let(:response_body) {'привет'.encode(Encoding::WINDOWS_1251)}
+      it_behaves_like 'uses default encoding'
+    end
+
+    context 'no charset dericitive' do
+      let(:response_headers) {{ 'content-type' => "text/html" }}
+      let(:response_body) {'привет'.encode(Encoding::WINDOWS_1251)}
+      it_behaves_like 'uses default encoding'
+    end
+  end
 end


### PR DESCRIPTION
Add the ability to set the default encoding for the responses that do not contain charset directive.

`
Faraday::Encoding.default_encoding = Encoding::UTF_8
`